### PR TITLE
Add GitHub Actions (CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  build-test:
+    strategy:
+      matrix:
+        python-version: [ '3.9' ]
+        os: [ macos-latest, ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+          cache: 'pip'
+
+      - name: Install 
+        run: pip install -r requirements.txt


### PR DESCRIPTION
- Add GitHub Actions
    - Since we have no Amplify token, we cannot run example or tests 
    - That's why this PR includes install test _only_
- GitHub Actions supports secret variables
    - https://docs.github.com/en/actions/security-guides/encrypted-secrets
    - It allows us to run examples/test 🤔 

### Example result

- https://github.com/y-yu/logic-expression-learning/actions/runs/1827211992